### PR TITLE
Automation Test - SCRUM-82: Testcase: [POST] Create Customer - Invalid email format

### DIFF
--- a/tests/endpoint/test_invalid_email_format.py
+++ b/tests/endpoint/test_invalid_email_format.py
@@ -1,0 +1,26 @@
+import pytest
+import requests
+
+@pytest.mark.api
+def test_invalid_email_format():
+    # Setup
+    url = "http://api.example.com/customer/"
+    headers = {
+        "Authorization": "Bearer <JWT token>",
+        "Content-Type": "application/json"
+    }
+    payload = {
+        "first_name": "John",
+        "last_name": "Doe",
+        "email": "invalid-email-format"
+    }
+
+    # Send API request
+    response = requests.post(url, json=payload, headers=headers)
+
+    # Assertions
+    assert response.status_code == 400, f"Expected status code 400, got {response.status_code}"
+    response_json = response.json()
+    assert "errorCode" in response_json and response_json["errorCode"] == "400", "Error code mismatch"
+    assert "errorMsg" in response_json and response_json["errorMsg"] == "Invalid email format", "Error message mismatch"
+    assert response.elapsed.total_seconds() <= 3, f"SLA exceeded: {response.elapsed.total_seconds()}s"


### PR DESCRIPTION
This pull request includes the automated test for JIRA ticket [SCRUM-82](https://elitea.atlassian.netbrowse/SCRUM-82). The test validates that an error is returned when attempting to create a customer with an invalid email format.